### PR TITLE
Sanitize parsed race positions

### DIFF
--- a/calc.js
+++ b/calc.js
@@ -94,18 +94,46 @@ function checkAndSetBoundaries(number, lowerBound, upperBound) {
 }
 
 function getPositions(input) {
+    if (!input) {
+        return [];
+    }
+
     const parts = input.split(',');
     const positions = [];
-    for (const part of parts) {
+
+    for (const rawPart of parts) {
+        const part = rawPart.trim();
+
+        if (!part) {
+            continue;
+        }
+
         if (part.includes('-')) {
-            const [start, end] = part.split('-').map(Number);
-            for (let i = start; i <= end; i++) {
+            const [startRaw, endRaw] = part.split('-');
+            const start = Number(startRaw.trim());
+            const end = Number(endRaw.trim());
+
+            if (Number.isNaN(start) || Number.isNaN(end)) {
+                continue;
+            }
+
+            const rangeStart = Math.min(start, end);
+            const rangeEnd = Math.max(start, end);
+
+            for (let i = rangeStart; i <= rangeEnd; i++) {
                 positions.push(i);
             }
         } else {
-            positions.push(Number(part));
+            const position = Number(part);
+
+            if (Number.isNaN(position)) {
+                continue;
+            }
+
+            positions.push(position);
         }
     }
+
     return positions;
 }
 


### PR DESCRIPTION
## Summary
- ignore blank segments when parsing manually-entered finishing positions
- trim whitespace and validate ranges so malformed input no longer produces invalid scores

## Testing
- node - <<'NODE'
const { readFileSync } = require('fs');
const vm = require('vm');
const script = readFileSync('calc.js', 'utf8');
const context = {
  console,
  document: {
    addEventListener() {},
    getElementById() { return { value: '', checked: false, style: {}, classList: { add(){}, remove(){} }, innerHTML: '', innerText: '' }; }
  },
  localStorage: {
    getItem() { return null; },
    setItem() {}
  }
};
vm.createContext(context);
vm.runInContext(script, context);
const inputs = ['', ' ', '1,,2', '3-5', '7 - 5', 'a', '1-2,4, ,8-7'];
for (const input of inputs) {
  console.log(JSON.stringify(input), '=>', context.getPositions(input));
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68ca538bf2e8832eb47efc202fefb999